### PR TITLE
Switch error() to Rf_error() to accommodate R-devel

### DIFF
--- a/R/iBMA.glm.R
+++ b/R/iBMA.glm.R
@@ -22,13 +22,14 @@ https://github.com/SurajGupta/r-source/blob/master/src/main/envir.c
 #define FRAME_LOCK_MASK (1<<14)
 #define FRAME_IS_LOCKED(e) (ENVFLAGS(e) & FRAME_LOCK_MASK)
 #define UNLOCK_FRAME(e) SET_ENVFLAGS(e, ENVFLAGS(e) & (~ FRAME_LOCK_MASK))
+#define R_NO_REMAP
 '
  
 src <- '
 if (TYPEOF(env) == NILSXP)
-error("use of NULL environment is defunct");
+Rf_error("use of NULL environment is defunct");
 if (TYPEOF(env) != ENVSXP)
-error("not an environment");
+Rf_error("not an environment");
  
 UNLOCK_FRAME(env);
  

--- a/R/iBMA.surv.R
+++ b/R/iBMA.surv.R
@@ -23,13 +23,14 @@ https://github.com/SurajGupta/r-source/blob/master/src/main/envir.c
 #define FRAME_LOCK_MASK (1<<14)
 #define FRAME_IS_LOCKED(e) (ENVFLAGS(e) & FRAME_LOCK_MASK)
 #define UNLOCK_FRAME(e) SET_ENVFLAGS(e, ENVFLAGS(e) & (~ FRAME_LOCK_MASK))
+#define R_NO_REMAP
 '
  
 src <- '
 if (TYPEOF(env) == NILSXP)
-error("use of NULL environment is defunct");
+Rf_error("use of NULL environment is defunct");
 if (TYPEOF(env) != ENVSXP)
-error("not an environment");
+Rf_error("not an environment");
  
 UNLOCK_FRAME(env);
  


### PR DESCRIPTION
Dear BMA team,

R Core is currently tightening the 'remapping' of C API functions. This lead to my R package `inline` failing in R-patched[^1]
An updated version of `inline` is now arriving at CRAN, but it breaks your package via the use of `inline`'s `cfunction()` in files `iBMA.surv.R` and `iBMA.glm.R` which both use `error()` which no longer resolves when `R_NO_REMAP` is set.

I have corrected this to `Rf_error()` in this PR. To not depend on a specific version of `inline`, I also define `R_NO_REMAP` which was straightforward as you define an `inc` text snippet with `#include` and `#define` statements.  The modified package passes tests here.

Please let me know if you have any questions.  I would expect that you may here from the CRAN team with a request for an update; they asked me to reach out to you.  The package looks to be in perfect standing so maybe you can just apply this PR and roll it into an updated version for CRAN.


[^1]: I made a slightly-too-clever change in November to change behavior if R-devel ie 4.5.0 or later is seen, not recognising that the `#define` could be set on its own which is what @kurthornik now does in R-patched. 